### PR TITLE
replace pylp with python-mip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ install-dev:
 
 .PHONY: test
 test:
-	python -m tests -v
+	pytest tests

--- a/comatch/match.py
+++ b/comatch/match.py
@@ -326,12 +326,12 @@ def match_components(
     label_matches = []
     for label_pair, label_indicator in binary_label_indicators.items():
         if True:
-            if label_indicator > 0.5:
+            if label_indicator.x > 0.5:
                 label_matches.append(label_pair)
 
     # get node matches
     node_matches = [
-        e for e in edges_xy if edge_indicators[e] > 0.5 and no_match_node not in e
+        e for e in edges_xy if edge_indicators[e].x > 0.5 and no_match_node not in e
     ]
 
     # get macroscopic errors counts
@@ -342,9 +342,9 @@ def match_components(
     fns = 0
     for label_pair, label_indicator in binary_label_indicators.items():
         if label_pair[0] == no_match_label:
-            fps += label_indicator > 0.5
+            fps += label_indicator.x > 0.5
         if label_pair[1] == no_match_label:
-            fns += label_indicator > 0.5
+            fns += label_indicator.x > 0.5
 
     fps -= 1
     fns -= 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pylp
+mip

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -4,7 +4,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 #logging.getLogger('comatch').setLevel(logging.DEBUG)
 
-if __name__ == "__main__":
+def test_match():
 
     nodes_x = list(range(1, 8))
     nodes_y = list(range(101, 111))


### PR DESCRIPTION
I was having some difficulty with pylp (not available for python 3.8, complaining about my boost libraries, reliant on conda, etc.) thought it might be faster/easier just to switch to python-mip.

Pros of python-mip
Similar to pylp, easy to switch between.
pip installable, not just conda.
They have pretty good documentation, examples, etc.
They have a nice feature of being able to name variables and constraints. I didn't really use that here since this model works for my purposes, but for debugging it seems like it could be very nice.
Support both gurobi and CBC (free and open source) solver. CPLEX and SCIP solvers apparently being worked on.

Alternatives:
[Google's or-tools](https://developers.google.com/optimization)
[PuLP](https://github.com/coin-or/PuLP)

I picked python-mip since I didn't know about the other 2 until recently. Haven't spent too much time comparing against the other alternatives.